### PR TITLE
Add collision prevention

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -18,3 +18,11 @@ var TaskFilename = "task.json"
 
 // DisplayProgressBar enables/disables the display of the progress bar.
 var DisplayProgressBar = isatty.IsTerminal(os.Stdout.Fd())
+
+// UseHashLength sets the length of the hash used to prevent collisions.
+// Note that this can never be more than 32
+var UseHashLength = 16
+
+// SaveWithHash enables/disables the collision protection using a hash
+// while moving the file from inside the program to outside.
+var SaveWithHash = true

--- a/download/download.go
+++ b/download/download.go
@@ -1,6 +1,7 @@
 package download
 
 import (
+	"github.com/MarcoTomasRodriguez/hget/config"
 	"github.com/MarcoTomasRodriguez/hget/logger"
 	"github.com/MarcoTomasRodriguez/hget/utils"
 	"os"
@@ -67,7 +68,15 @@ func Download(url string, task *Task, parallelism int, skipTLS bool) {
 					return
 				}
 			} else {
-				err = JoinFile(files, filepath.Base(url))
+				var outputName string
+
+				if config.SaveWithHash {
+					outputName = utils.FilenameWithHash(url)
+				} else {
+					outputName = utils.FilenameWithoutHash(url)
+				}
+
+				err = JoinFile(files, outputName)
 				utils.FatalCheck(err)
 
 				err = os.RemoveAll(utils.FolderOf(url))

--- a/download/joiner.go
+++ b/download/joiner.go
@@ -21,7 +21,7 @@ func copyFile(src string, destFile *os.File) error {
 }
 
 // JoinFile joins all the parts of a file and saves them in the output path.
-func JoinFile(files []string, out string) error {
+func JoinFile(files []string, outputPath string) error {
 	var bar *pb.ProgressBar
 
 	// sort with file name or we will join files with wrong order
@@ -32,12 +32,12 @@ func JoinFile(files []string, out string) error {
 		bar = pb.StartNew(len(files)).Prefix(color.CyanString("Joining"))
 	}
 
-	outFile, err := os.OpenFile(out, os.O_CREATE|os.O_WRONLY, 0600)
+	outputFile, err := os.OpenFile(outputPath, os.O_CREATE|os.O_WRONLY, 0600)
 	if err != nil { return err }
-	defer outFile.Close()
+	defer outputFile.Close()
 
 	for _, file := range files {
-		if err = copyFile(file, outFile); err != nil { return err }
+		if err = copyFile(file, outputFile); err != nil { return err }
 
 		if bar != nil { bar.Increment() }
 	}

--- a/download/task.go
+++ b/download/task.go
@@ -16,7 +16,7 @@ type Task struct {
 	Parts []Part
 }
 
-// Part is a slice of the file.
+// Part is a slice of the file downloaded.
 type Part struct {
 	Url       string
 	Path      string

--- a/download/task_test.go
+++ b/download/task_test.go
@@ -10,28 +10,27 @@ import (
 )
 
 func TestTask(t *testing.T) {
-	pathToProgram := filepath.Join(config.Home, config.ProgramFolder)
 	task := Task{Url: "localhost/my_file.file", Parts: []Part{}}
 	task2 := Task{Url: "localhost/another-file", Parts: []Part{}}
 
 	assert.NoError(t, task.SaveTask())
 
-	assert.True(t, utils.ExistDir(filepath.Join(pathToProgram, "my_file.file")))
-	assert.True(t, utils.ExistDir(filepath.Join(pathToProgram, "my_file.file", config.TaskFilename)))
+	assert.True(t, utils.ExistDir(utils.FolderOf(task.Url)))
+	assert.True(t, utils.ExistDir(filepath.Join(utils.FolderOf(task.Url), config.TaskFilename)))
 
 	assert.NoError(t, task2.SaveTask())
 
-	assert.True(t, utils.ExistDir(filepath.Join(pathToProgram, "another-file")))
-	assert.True(t, utils.ExistDir(filepath.Join(pathToProgram, "another-file", config.TaskFilename)))
+	assert.True(t, utils.ExistDir(utils.FolderOf(task2.Url)))
+	assert.True(t, utils.ExistDir(filepath.Join(utils.FolderOf(task2.Url), config.TaskFilename)))
 
 	tasks, err := GetAllTasks()
-	actualTasks := []string{"file", "my_file.file", "another-file"}
+	actualTasks := []string{utils.FilenameWithHash(task.Url), utils.FilenameWithHash(task2.Url)}
 	sort.Strings(tasks)
 	sort.Strings(actualTasks)
 	assert.NoError(t, err)
 	assert.Equal(t, tasks, actualTasks)
 
-	savedTask, err := ReadTask("my_file.file")
+	savedTask, err := ReadTask(utils.FilenameWithHash(task.Url))
 	assert.NoError(t, err)
 	assert.Equal(t, task, *savedTask)
 }

--- a/main.go
+++ b/main.go
@@ -7,15 +7,14 @@ import (
 	"github.com/MarcoTomasRodriguez/hget/logger"
 	"github.com/MarcoTomasRodriguez/hget/utils"
 	"os"
-	"path/filepath"
 	"runtime"
 )
 
 func printUsage() {
 	logger.Info(`Usage:
-hget [URL] [-n connection] [-skip-tls true]
+hget [URL] [-n CPUs] [-skip-tls true]
 hget tasks
-hget resume [TaskName]
+hget resume [TaskName | URL]
 `)
 }
 
@@ -29,14 +28,14 @@ func tasksCommand() {
 
 func resumeCommand(args []string, conn *int, skipTLS *bool) {
 	if len(args) < 2 {
-		logger.Error("downloading taskName name is required\n")
+		logger.Error("TaskName or URL is required\n")
 		printUsage()
 		os.Exit(1)
 	}
 
 	var taskName string
 	if utils.IsUrl(args[1]) {
-		taskName = filepath.Base(args[1])
+		taskName = utils.FilenameWithHash(args[1])
 	} else {
 		taskName = args[1]
 	}
@@ -60,13 +59,13 @@ func downloadCommand(args []string, conn *int, skipTLS *bool) {
 }
 
 func main() {
-	conn    := flag.Int("n", runtime.NumCPU(), "connection")
+	conn    := flag.Int("n", runtime.NumCPU(), "number of threads")
 	skipTLS := flag.Bool("skip-tls", true, "skip verify certificate for https")
 
 	flag.Parse()
 	args := flag.Args()
 	if len(args) < 1 {
-		logger.Error("url is required\n")
+		logger.Error("URL is required\n")
 		printUsage()
 		os.Exit(1)
 	}

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -83,6 +83,10 @@ func FilenameWithoutHash(url string) string {
 		logger.Panic(errors.New("there is no basename for the url"))
 	}
 
+	if len(filename) > FilenameLengthLimit {
+		logger.Panic(fmt.Errorf("the filename length should never exceed the limit of %d", FilenameLengthLimit))
+	}
+
 	return filename
 }
 

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"crypto/sha256"
 	"errors"
 	"fmt"
 	"github.com/MarcoTomasRodriguez/hget/config"
@@ -13,6 +14,7 @@ import (
 )
 
 const (
+	FilenameLengthLimit = 255
 	Byte = 1
 	KiloByte = 1024 * Byte
 	MegaByte = 1024 * KiloByte
@@ -52,15 +54,42 @@ func ExistDir(folder string) bool {
 	return err == nil
 }
 
-// FolderOf gets the folder of a download safely.
-func FolderOf(url string) string {
+// HashOf returns the sha256 sum256 hash of the parameter.
+func HashOf(str string) string {
+	return fmt.Sprintf("%x", sha256.Sum256([]byte(str)))
+}
+
+// RemoveHashFromFilename returns the basename + the hash of the url.
+func FilenameWithHash(url string) string {
 	base := filepath.Base(url)
+	hash := HashOf(url)[:config.UseHashLength]
 	if base == "." {
 		logger.Panic(errors.New("there is no basename for the url"))
 	}
 
+	filename := hash + "-" + base
+	if len(filename) > FilenameLengthLimit {
+		logger.Panic(fmt.Errorf("the filename length should never exceed the limit of %d",
+			FilenameLengthLimit - len(hash) + 1))
+	}
+
+	return filename
+}
+
+// FilenameWithoutHash returns the basename of the url.
+func FilenameWithoutHash(url string) string {
+	filename := filepath.Base(url)
+	if filename == "." {
+		logger.Panic(errors.New("there is no basename for the url"))
+	}
+
+	return filename
+}
+
+// FolderOf gets the folder of a download safely.
+func FolderOf(url string) string {
 	safePath := filepath.Join(config.Home, config.ProgramFolder)
-	fullQualifyPath, err := filepath.Abs(filepath.Join(config.Home, config.ProgramFolder, filepath.Base(url)))
+	fullQualifyPath, err := filepath.Abs(filepath.Join(config.Home, config.ProgramFolder, FilenameWithHash(url)))
 	FatalCheck(err)
 
 	// must ensure full qualify path is CHILD of safe path

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -30,24 +30,6 @@ func TestHashOf(t *testing.T) {
 	assert.NotEqual(t, HashOf(data[0]), HashOf(data[1]))
 }
 
-/*
-// RemoveHashFromFilename returns the basename + the hash of the url.
-func FilenameWithHash(url string) string {
-	base := filepath.Base(url)
-	hash := HashOf(url)[:config.UseHashLength]
-	if base == "." {
-		logger.Panic(errors.New("there is no basename for the url"))
-	}
-
-	filename := hash + "-" + base
-	if len(filename) > FilenameLengthLimit {
-		logger.Panic(fmt.Errorf("the filename length should never exceed the limit of %d",
-			FilenameLengthLimit - len(hash) + 1))
-	}
-
-	return filename
-}
-*/
 func TestFilenameWithHash(t *testing.T) {
 	data := []string{"localhost", "localhost/my-file.file"}
 
@@ -57,7 +39,17 @@ func TestFilenameWithHash(t *testing.T) {
 
 	assert.Panics(t, func() { FilenameWithHash(".") } )
 	assert.Panics(t, func() { FilenameWithHash(strings.Repeat("-", 255)) } )
+}
 
+func TestFilenameWithoutHash(t *testing.T) {
+	data := []string{"localhost", "localhost/my-file.file"}
+
+	for _, url := range data {
+		assert.Equal(t, filepath.Base(url), FilenameWithoutHash(url))
+	}
+
+	assert.Panics(t, func() { FilenameWithHash(".") } )
+	assert.Panics(t, func() { FilenameWithHash(strings.Repeat("-", 256)) } )
 }
 
 func TestFolderOf(t *testing.T) {

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -5,6 +5,7 @@ import (
 	"github.com/MarcoTomasRodriguez/hget/config"
 	"github.com/stretchr/testify/assert"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -19,9 +20,54 @@ func TestMkdirIfNotExist(t *testing.T) {}
 
 func TestExistDir(t *testing.T) {}
 
+func TestHashOf(t *testing.T) {
+	data := []string{"test", "file", "test-test-test-test-test-test", "test-test-test-test-test-test-test-test-test-test-test"}
+
+	for _, str := range data {
+		assert.Equal(t, HashOf(str), HashOf(str))
+	}
+
+	assert.NotEqual(t, HashOf(data[0]), HashOf(data[1]))
+}
+
+/*
+// RemoveHashFromFilename returns the basename + the hash of the url.
+func FilenameWithHash(url string) string {
+	base := filepath.Base(url)
+	hash := HashOf(url)[:config.UseHashLength]
+	if base == "." {
+		logger.Panic(errors.New("there is no basename for the url"))
+	}
+
+	filename := hash + "-" + base
+	if len(filename) > FilenameLengthLimit {
+		logger.Panic(fmt.Errorf("the filename length should never exceed the limit of %d",
+			FilenameLengthLimit - len(hash) + 1))
+	}
+
+	return filename
+}
+*/
+func TestFilenameWithHash(t *testing.T) {
+	data := []string{"localhost", "localhost/my-file.file"}
+
+	for _, url := range data {
+		assert.Equal(t, HashOf(url)[:config.UseHashLength] + "-" + filepath.Base(url), FilenameWithHash(url))
+	}
+
+	assert.Panics(t, func() { FilenameWithHash(".") } )
+	assert.Panics(t, func() { FilenameWithHash(strings.Repeat("-", 255)) } )
+
+}
+
 func TestFolderOf(t *testing.T) {
-	assert.Equal(t, FolderOf("localhost/my-file.file"), filepath.Join(config.Home, config.ProgramFolder, "my-file.file"))
-	assert.Equal(t, FolderOf("localhost"), filepath.Join(config.Home, config.ProgramFolder, "localhost"))
+	// HashOf("localhost")[:config.UseHashLength] + "-localhost"
+	data := []string{"localhost", "localhost/my-file.file"}
+
+	for _, url := range data {
+		assert.Equal(t, filepath.Join(config.Home, config.ProgramFolder, FilenameWithHash(url)), FolderOf(url))
+	}
+
 	assert.Panics(t, func() { FolderOf("localhost/../") })
 	assert.Panics(t, func() { FolderOf("localhost/.") })
 	assert.Panics(t, func() { FolderOf("") })


### PR DESCRIPTION
Adds collision prevention by hashing the URL and adding it to the task name.

Fixes #11 